### PR TITLE
Better handling of multi-valued attributes

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/cas/spring/CasEventListener.java
+++ b/src/main/java/org/jenkinsci/plugins/cas/spring/CasEventListener.java
@@ -4,6 +4,7 @@ import hudson.tasks.Mailer;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Collection;
 
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.GrantedAuthorityImpl;
@@ -127,7 +128,11 @@ public class CasEventListener implements ApplicationListener {
 			Map attributes = authToken.getAssertion().getPrincipal().getAttributes();
 			Object attribute = attributes.get(attributeName);
 			if (attribute != null) {
-				return attribute.toString();
+				if (attribute instanceof Collection) {
+					return ((Collection<String>)attribute).iterator().next();
+				} else {
+					return attribute.toString();
+				}
 			}
 		}
 		return null;


### PR DESCRIPTION
This commit modifies the behaviour of getAttributeValue() so that when
multiple values are present in the CAS token, only the first is
returned. This is useful mostly to handle multiple email addresses.
